### PR TITLE
Fixed wrong function call `fetch` to `get` in example.js

### DIFF
--- a/examples/example.js
+++ b/examples/example.js
@@ -14,7 +14,7 @@ registry.set(
   });
 
 let ExampleConnector = require('./ExampleConnector').Connector;
-let executor = new Executor(ExampleConnector, registry.fetch('example-entry'));
+let executor = new Executor(ExampleConnector, registry.get('example-entry'));
 
 let context = {
   username: 'example-user',


### PR DESCRIPTION
The example won't run because it is calling the wrong function

Should be calling `get` instead of `fetch`