### PR TITLE
feat(iamx): add support for yaml merge key

### DIFF
--- a/lib/core/CredentialsRegistry.js
+++ b/lib/core/CredentialsRegistry.js
@@ -14,7 +14,7 @@ const YAML = require('yaml');
 let credRegistry = {};
 
 /**
- * Expose public methods 
+ * Expose public methods
  */
 exports.Registry = {
   set:      set,
@@ -26,7 +26,7 @@ exports.Registry = {
 
 /**
  * Set a master credential in the registry
- * 
+ *
  * @param {String} key
  * @param {String} engine
  * @param {Object} data
@@ -40,7 +40,7 @@ function set (key, engine, data = {}) {
 
 /**
  * Remove a master credential from the registry
- * 
+ *
  * @param {String} key
  */
 function remove (key) {
@@ -49,7 +49,7 @@ function remove (key) {
 
 /**
  * Get value from credentials registry
- * 
+ *
  * @param {String} key
  */
 function get (key) {
@@ -65,12 +65,17 @@ function truncate () {
 
 /**
  * Load value from YAML
- * 
+ *
  * @param {String} filepath
  */
 function loadYAML (filepath) {
   let fileContent = fs.readFileSync(filepath, 'utf8');
-  let registryObjects = YAML.parse(fileContent);
+
+  // Enable merge keys (<<: *anchor_name) so that we can use anchor tag (&anchor_name)
+  // and merge key to reduce duplication in the credentials registry config file
+  // Ref: https://github.com/eemeli/yaml/blob/master/docs/03_options.md#schema-options
+  let registryObjects = YAML.parse(fileContent, { merge: true });
+
   (registryObjects).forEach(regObject => {
     set(regObject.key, regObject.engine, regObject.data);
   });

--- a/lib/core/Executor.js
+++ b/lib/core/Executor.js
@@ -5,7 +5,7 @@ const REVOKE      = 'revoke';
 const SHOW        = 'show';
 const FETCH_BATCH = 'fetchBatch';
 const LIST_AVAILABLE_ACCESS_CONTEXT = 'listAvailableAccessContext';
-const VERSION     = '1.2.0';
+const VERSION     = '1.2.1';
 
 /**
  * The class for executor objects. The executor object carries out the execution of the IAM workflow

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cermati/iamx",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cermati/iamx",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Centralized IAM",
   "main": "lib/index.js",
   "dependencies": {

--- a/test/CredentialsRegistryTest.js
+++ b/test/CredentialsRegistryTest.js
@@ -7,41 +7,54 @@ let assert = require('chai').assert;
 describe('Credentials Registry', () => {
   let credReg = require('../lib/index').CredentialsRegistry;
   let sampleYAML = 'test/sample.yml';
-  let sampleRegVal = {
-    key: 'sample-key',
-    engine: 'sample-engine',
-    data: {
-      credentials: {
-        username: 'sample-username',
-        password: 'sample-password'
+  let expectedRegVal = [
+    {
+      key: 'sample-key',
+      engine: 'sample-engine',
+      data: {
+        credentials: {
+          username: 'sample-username',
+          password: 'sample-password'
+        }
       }
-    }
-  };
+    },
+    {
+      key: 'sample-key-2',
+      engine: 'sample-engine',
+      data: {
+        credentials: {
+          username: 'sample-username',
+          password: 'sample-password'
+        }
+      }
+    },
+  ];
+
+  credReg.set(expectedRegVal[0].key, expectedRegVal[0].engine, expectedRegVal[0].data);
 
   it('can set and get value to registry', () => {
-    credReg.set(sampleRegVal.key, sampleRegVal.engine, sampleRegVal.data);
-    let retrievedRegVal = credReg.get(sampleRegVal.key);
+    let retrievedRegVal = credReg.get(expectedRegVal[0].key);
 
-    assert.equal(retrievedRegVal.engine, sampleRegVal.engine);
-    assert.equal(retrievedRegVal.data.credentials.username, sampleRegVal.data.credentials.username);
-    assert.equal(retrievedRegVal.data.credentials.password, sampleRegVal.data.credentials.password);
+    assert.equal(retrievedRegVal.engine, expectedRegVal[0].engine);
+    assert.equal(retrievedRegVal.data.credentials.username, expectedRegVal[0].data.credentials.username);
+    assert.equal(retrievedRegVal.data.credentials.password, expectedRegVal[0].data.credentials.password);
   });
 
   it('can truncate registry value', () => {
-    let retrievedRegVal = credReg.get(sampleRegVal.key);
-    assert.equal(retrievedRegVal.engine, sampleRegVal.engine);
+    let retrievedRegVal = credReg.get(expectedRegVal[0].key);
+    assert.equal(retrievedRegVal.engine, expectedRegVal[0].engine);
 
     credReg.truncate();
-    retrievedRegVal = credReg.get(sampleRegVal.key);
+    retrievedRegVal = credReg.get(expectedRegVal[0].key);
     assert.equal(retrievedRegVal, undefined);
   });
 
-  it('can load values from YAML', () => {
+  it('can load values from YAML with anchor and merge key', () => {
     credReg.loadYAML(sampleYAML);
-    let retrievedRegVal = credReg.get(sampleRegVal.key);
+    let retrievedRegVal = credReg.get(expectedRegVal[1].key);
 
-    assert.equal(retrievedRegVal.engine, sampleRegVal.engine);
-    assert.equal(retrievedRegVal.data.credentials.username, sampleRegVal.data.credentials.username);
-    assert.equal(retrievedRegVal.data.credentials.password, sampleRegVal.data.credentials.password);
+    assert.equal(retrievedRegVal.engine, expectedRegVal[1].engine);
+    assert.equal(retrievedRegVal.data.credentials.username, expectedRegVal[1].data.credentials.username);
+    assert.equal(retrievedRegVal.data.credentials.password, expectedRegVal[1].data.credentials.password);
   });
 });

--- a/test/sample.yml
+++ b/test/sample.yml
@@ -1,6 +1,10 @@
-- key: sample-key
+- &base_creds_data
+  key: sample-key
   engine: sample-engine
   data:
     credentials:
       username: sample-username
       password: sample-password
+
+- <<: *base_creds_data
+  key: sample-key-2


### PR DESCRIPTION
Enable merge keys (`<<: *anchor_name`) so that we can use anchor tag (`&anchor_name`) and merge key to reduce duplication in the credentials registry config file.
Ref: https://github.com/eemeli/yaml/blob/master/docs/03_options.md#schema-options